### PR TITLE
Edits

### DIFF
--- a/draft-arkko-abcd-distributed-resolver-selection.md
+++ b/draft-arkko-abcd-distributed-resolver-selection.md
@@ -76,8 +76,6 @@ Note that there are also other possible goals, e.g., around discovery of DNS ser
 
 This section introduces and analyzes several potential strategies for distributing queries to different resolvers. Each strategy is formulated as an algorithm for choosing a resolver Ri from a set of n resolvers R1, R2, ...,  Rn.
 
-Note that the list of algorithms may grow in a future version of this memo; this set is the initially analyzed set.
-
 The designs presented in {{algorithms}} assume that the stub resolver performing distribution of queries has varying degrees of contextual information.  In general, more contextual information allows for finer-grained distribution of information between resolvers.
 
 

--- a/draft-arkko-abcd-distributed-resolver-selection.md
+++ b/draft-arkko-abcd-distributed-resolver-selection.md
@@ -47,21 +47,15 @@ This memo discusses the use of a set of different DNS resolvers to reduce privac
 
 # Introduction {#introduction}
 
-Internet communications are increasingly protected by use of encryption {{?TLS13=RFC8446}}, {{?QUIC=I-D.ietf-quic-transport}}, {{?ESNI=I-D.ietf-tls-esni}}.
-
-Encryption of DNS transport between stub and recursive resolvers is defined in {{!DOT=RFC7858}} and {{!DOH=RFC8484}}.  These protocols provide confidentiality for DNS queries to a recursive resolver.
+The DNS protocol {{!DNS=RFC1035}} provides no confidentiality; and therefore no privacy protections for queries.  Encryption of DNS transport between stub and recursive resolvers as defined in {{!DOT=RFC7858}} and {{!DOH=RFC8484}} provides confidentiality for DNS queries between a stub and a recursive resolver.
 
 Recursive resolvers present a privacy dichotomy for clients.  A recursive resolver that aggregates queries from multiple clients provides a measure of anonymity for those clients, both for authoritative servers and from other observers on the network.  Aggregating requests from multiple clients makes it difficult for these entities to correlate queries with specific clients.  The potential for a recursive to answer queries from cache further improves this privacy advantage, while providing significant query latency gains.  However, because the recursive resolver sees and can record DNS queries, using a recursive resolver creates a privacy exposure for clients.
 
 A client might decide to trust a particular recursive resolver with information about DNS queries.  However, it is difficult or impossible to provide any guarantees about data handling practices in the general case.  And even if a service can be trusted to respect privacy with respect to handling of query data, legal and commercial pressures or surveillance activity could result misuse of data.  Similarly, it is not possible to make any guarantees about attacks on services.  For a service with many clients, these risks are particularly undesirable.
 
-Defending against privacy leaks for DNS queries is particularly important given the prevalence of pervasive surveillance efforts {{RFC7258}}.
-
 This memo describes techniques for distributing DNS queries between multiple recursive resolvers from a known set.  The goal is to reduce the amount of information that any signal DNS resolver is able to gain and thereby reduce the amount of privacy-sensitive information that can be collected in one place.  The characteristics of different choices are examined.
 
 An important outcome of this analysis is that simplistic methods for distributing queries -- such as a round-robin algorithm -- have considerably worse privacy characteristics than using a single recursive resolver.
-
-There are many other worthwhile topics in the general space of providing better confidentiality or privacy for DNS queries, or for operating encrypted DNS query services. Topics such as resolver discovery, operational practices at any individial resolver service, etc. are outside the scope of this memo.
 
 The rest of this memo is organized as follows. {{goals}} specifies the requirements that we would like such a distribution arrangement to provide. {{algorithms}} discusses the different strategies, and makes some early recommendations among the strategies. {{furtherwork}} discusses potential further work in this area.
 

--- a/draft-arkko-abcd-distributed-resolver-selection.md
+++ b/draft-arkko-abcd-distributed-resolver-selection.md
@@ -31,12 +31,7 @@ author:
 normative:
 
 informative:
-  RFC1035:
   RFC7258:
-  RFC8446:
-  RFC8484:
-  I-D.ietf-tls-esni:
-  I-D.ietf-quic-transport:
   I-D.schinazi-httpbis-doh-preference-hints:
   MSCVUS:
    title: Microsoft Corp. v. United States
@@ -52,17 +47,21 @@ This memo discusses the use of a set of different DNS resolvers to reduce privac
 
 # Introduction {#introduction}
 
-Internet communications are increasingly protected, by use of encryption {{RFC8446}}, {{RFC8484}}, {{I-D.ietf-quic-transport}}, {{I-D.ietf-tls-esni}}.
+Internet communications are increasingly protected by use of encryption {{?TLS13=RFC8446}}, {{?QUIC=I-D.ietf-quic-transport}}, {{?ESNI=I-D.ietf-tls-esni}}.
 
-When a DNS client {{RFC1035}} uses a resolver service, that service learns what applications the user is using, what web sites are visited, and so on. Even with the protection of communications, DNS resolvers themselves remain as a persistent vulnerability with respect to privacy as it is aware of both the client and their usage patterns.
+Encryption of DNS transport between stub and recursive resolvers is defined in {{!DOT=RFC7858}} and {{!DOH=RFC8484}}.  These protocols provide confidentiality for DNS queries to a recursive resolver.
 
-Leaking this information to the Internet infrastructure component such as a DNS resolver service can be problematic when the service is not entirely trusted. And even when  the service is trusted and well maintained, legal and commercial pressures or surveillance activity may result in some of the information given to the service to be misused, particularly when a service holds information for a large number of users. This is not desirable.
+Recursive resolvers present a privacy dichotomy for clients.  A recursive resolver that aggregates queries from multiple clients provides a measure of anonymity for those clients, both for authoritative servers and from other observers on the network.  Aggregating requests from multiple clients makes it difficult for these entities to correlate queries with specific clients.  The potential for a recursive to answer queries from cache further improves this privacy advantage, while providing significant query latency gains.  However, because the recursive resolver sees and can record DNS queries, using a recursive resolver creates a privacy exposure for clients.
+
+A client might decide to trust a particular recursive resolver with information about DNS queries.  However, it is difficult or impossible to provide any guarantees about data handling practices in the general case.  And even if a service can be trusted to respect privacy with respect to handling of query data, legal and commercial pressures or surveillance activity could result misuse of data.  Similarly, it is not possible to make any guarantees about attacks on services.  For a service with many clients, these risks are particularly undesirable.
 
 Defending against privacy leaks for DNS queries is particularly important given the prevalence of pervasive surveillance efforts {{RFC7258}}.
 
-This memo discusses the use of a set of different DNS resolvers to reduce privacy problems related to DNS resolvers. The architectural principle followed here is one of attempting to avoid high-value targets and the concentration of any individual users's information in one place. We outline a number of different strategies for distributing queries to the different resolvers and analyze the privacy and other impacts of those strategies. Our observation is that a simplistic models -- such as a round-robin algorithm -- are not necessarily the best suited for this task.
+This memo describes techniques for distributing DNS queries between multiple recursive resolvers from a known set.  The goal is to reduce the amount of information that any signal DNS resolver is able to gain and thereby reduce the amount of privacy-sensitive information that can be collected in one place.  The characteristics of different choices are examined.
 
-The focus of this document is precisely only the choice of a resolver from a known set. There are many other worthwhile topics in the general space of providing better confidentiality or privacy for DNS queries, or for operating encrypted DNS query services. Topics such as resolver discovery, operational practices at any individial resolver service, etc. are outside the scope of this memo.
+An important outcome of this analysis is that simplistic methods for distributing queries -- such as a round-robin algorithm -- have considerably worse privacy characteristics than using a single recursive resolver.
+
+There are many other worthwhile topics in the general space of providing better confidentiality or privacy for DNS queries, or for operating encrypted DNS query services. Topics such as resolver discovery, operational practices at any individial resolver service, etc. are outside the scope of this memo.
 
 The rest of this memo is organized as follows. {{goals}} specifies the requirements that we would like such a distribution arrangement to provide. {{algorithms}} discusses the different strategies, and makes some early recommendations among the strategies. {{furtherwork}} discusses potential further work in this area.
 

--- a/draft-arkko-abcd-distributed-resolver-selection.md
+++ b/draft-arkko-abcd-distributed-resolver-selection.md
@@ -68,7 +68,13 @@ For instance, some web sites use names that are appear unrelated to their primar
 
 A distribution scheme also needs to consider stability of query routing over time.  A resolver can observve the absence of queries and infer things about the state of a client cache, which can reveal that queries were made to other resolvers.
 
-The need to limit replication of private information about queries eliminates simplistic distribution schemes, such as those discussed in {{bad-algorithms}}.
+In effect, there are two goals in tension:
+
+* to split queries between as many different resolvers as possible; and
+
+* to reduce the spread of information about related queries across multiple resolvers.
+
+The need to limit replication of private information about queries eliminates simplistic distribution schemes, such as those discussed in {{bad-algorithms}}.  The designs described in {{algorithms}} all attempt to balance these different goals using different properties from the context of a query ({{clientbased}}) or the query name itself ({{namebased}}).
 
 Note that there are also other possible goals, e.g., around discovery of DNS servers (see, e.g., {{I-D.schinazi-httpbis-doh-preference-hints}}). These goals are outside the scope of this memo, as it is only concerned with selection from a set of known servers.
 
@@ -77,7 +83,6 @@ Note that there are also other possible goals, e.g., around discovery of DNS ser
 This section introduces and analyzes several potential strategies for distributing queries to different resolvers. Each strategy is formulated as an algorithm for choosing a resolver Ri from a set of n resolvers R1, R2, ...,  Rn.
 
 The designs presented in {{algorithms}} assume that the stub resolver performing distribution of queries has varying degrees of contextual information.  In general, more contextual information allows for finer-grained distribution of information between resolvers.
-
 
 ## Client-based {#clientbased}
 
@@ -129,7 +134,7 @@ Each of these techniques are potentially unreliable in different ways.  Addition
 
 # Effects of query distribution
 
-Choosing to use more than one DNS resolver has broader implications than just the effect on privacy.
+Choosing to use more than one DNS resolver has broader implications than just the effect on privacy.  Using multiple resolvers is a significant change from the assumed model where stub resolvers send all queries to a single resolver.
 
 ## Caching considerations {#caching}
 
@@ -137,13 +142,17 @@ Using a common cache for multiple resolvers introduces the possibility that a re
 
 ## Consistency considerations
 
-Making the same query to multiple resolvers can result in different answers.  For instance, DNS-based load balancing can lead to different answers being produced over time or for different query origins.
+Making the same query to multiple resolvers can result in different answers.  For instance, DNS-based load balancing can lead to different answers being produced over time or for different query origins.  Or, different resolvers might have different policies with respect to blocking or filtering of queries that lead to clients receiving inconsistent answers.
 
 In the extreme, an application might encounter errors as a result of receiving incompatible answers, particularly if a server operator (incorrectly) assumes that different DNS queries for the same client always originate from the same source address.  This is most likely to occur if name-based selection is used, as queries could be related based on information that the client does not consider.
 
 ## Resolver load distribution
 
 Any selection of resolvers that is based on random inputs will need to account for available capacity on resolvers.  Otherwise, resolvers with less available query-processing capacity will receive too high a proportion of all queries.  Clients only need to be informed of relative available capacity in order to make an appropriate selection.  How relative capacities of resolvers are determined is not in scope for this document.
+
+## Query performance
+
+Distribution of queries between resolvers also means that clients are exposed to greater variations in performance.
 
 # Poor distribution algorithms {#bad-algorithms}
 
@@ -161,7 +170,8 @@ Implementing either method at a much slower cadence might be effective, subject 
 
 # Further work {#furtherwork}
 
-TBD
+More work is needed to determine factors other than privacy that could motivate having queries routed to the same resolver.
+
 
 --- back
 

--- a/draft-arkko-abcd-distributed-resolver-selection.md
+++ b/draft-arkko-abcd-distributed-resolver-selection.md
@@ -109,7 +109,7 @@ When the hash function only takes into account the name and nothing else, differ
 
 Note that any hash-based distribution to a set of resolvers may or may not distribute traffic to the resolvers equally. For instance, a popular domain may get a lot of queries, but is just one name from the point of view of the hash. Further work may be needed on this.
 
-Mention public suffix, and also the equivalence lists that Mozilla uses: https://github.com/mozilla-services/shavar-prod-lists/blob/master/disconnect-entitylist.json
+Mention public suffix, and also the equivalence lists that Mozilla uses: https://github.com/mozilla-services/shavar-prod-lists/blob/master/disconnect-entitylist.json  And then talk about first party sets: https://github.com/krgovind/first-party-sets
 
 ## Suffix-based
 

--- a/draft-arkko-abcd-distributed-resolver-selection.md
+++ b/draft-arkko-abcd-distributed-resolver-selection.md
@@ -81,15 +81,19 @@ The designs presented in {{algorithms}} assume that the stub resolver performing
 
 ## Client-based {#clientbased}
 
-The simplest algorithm is to distribute each different client to a different resolver. This reduces the number of users any particular service will know about. However, in order to function properly, this methods needs to apply some kind of stable assignment mechanism, e.g., a stable hash.
+The simplest algorithm is to distribute each different client to a different resolver. This reduces the number of users any particular service will know about.  However, this does little to protect an individual user from the aggregation of information about queries at the selected resolver.
 
-One way of doing this is to hash the client's identity in some manner:
+In this design clients select and consistently use the same resolver.  This might be achieved by randomly selecting and remembering a resolver.  Alternatively, a resolver might be selected using consistent hashing that takes some conception of client identity as input:
 
     i = h(client identity) % n
 
-Note that the client identity can (and should) be something that remains private to the client itself; the resolver service need not be told about the identity, even if the client's concept of its own identity leads it to select a particular resolver service. To avoid disclosing DNS usage patterns to all resolvers, the identity needs to be persistent information, perhaps obtained from the operating system, user account, hardware, or a random value chosen upon the first use of the application.
+For the purposes of this determination, a client might be an entire device, with the selection being made at the operating system level, or it could be a selection made by individual applications.
 
-While this algorithm satisfies the first overall goal in {{goals}}, it does nothing about splitting information regarding a particular client to different services. The only privacy benefit it provides is that it reduces the number of clients that each resolver service provider has information about. This may discourage attacking that service, or forcing the service to give out information. But for each individual client, there is still some resolver service that knows everything about the user's DNS usage patterns.
+Where different applications make independent resolver selections, activities that involve multiple applications can result in information about those activities being exposed to multiple resolvers.  For instance, an application could open another application for the purposes of handling a specific file type or to load a URL.  This could expose queries related to the activity as a whole to multiple resolvers.
+
+Even making different selections at the level of a device can result in replicating related information to multiple resolvers.  For instance, an individual who uses a particular application on multiple devices might perform similar activities on those devices, but have DNS queries distributed to different resolvers.
+
+While this algorithm provides distribution of DNS queries in the aggregate, it does little to divide information about a particular client between resolvers. It effectively only reduces the number of clients that each resolver can acquire information about. This provides systemic benefit, but does not provide individual clients with any significant advantage as there is still some resolver service that has a complete view of the user's DNS usage patterns.
 
 ## Name-based {#namebased}
 

--- a/draft-arkko-abcd-distributed-resolver-selection.md
+++ b/draft-arkko-abcd-distributed-resolver-selection.md
@@ -31,7 +31,6 @@ author:
 normative:
 
 informative:
-  RFC7258:
   I-D.schinazi-httpbis-doh-preference-hints:
   MSCVUS:
    title: Microsoft Corp. v. United States

--- a/draft-arkko-abcd-distributed-resolver-selection.md
+++ b/draft-arkko-abcd-distributed-resolver-selection.md
@@ -87,7 +87,7 @@ In this design clients select and consistently use the same resolver.  This migh
 
     i = h(client identity) % n
 
-For the purposes of this determination, a client might be an entire device, with the selection being made at the operating system level, or it could be a selection made by individual applications.
+For the purposes of this determination, a client might be an entire device, with the selection being made at the operating system level, or it could be a selection made by individual applications.  In the extreme, an individual application might be able to partition its activities in a way that allows it to direct queries to multiple resolvers.
 
 Where different applications make independent resolver selections, activities that involve multiple applications can result in information about those activities being exposed to multiple resolvers.  For instance, an application could open another application for the purposes of handling a specific file type or to load a URL.  This could expose queries related to the activity as a whole to multiple resolvers.
 
@@ -97,7 +97,7 @@ While this algorithm provides distribution of DNS queries in the aggregate, it d
 
 ## Name-based {#namebased}
 
-The clients may distribute their queries based on the name being queried. This results in different names going to different services, e.g., a social network name goes to a different service than a search engine name:
+The clients might distribute their queries based on the name being queried. This results in different names going to different services, e.g., a social network name goes to a different service than a search engine name:
 
     i = h(queried name) % n
 
@@ -108,6 +108,8 @@ This approach may also be extended to cover moving hosts by incorporating the pu
 When the hash function only takes into account the name and nothing else, different clients will algorithmically arrive at the use of the same resolver for the same names. This can be undesirable. When address and identity information is used alongside the name, this is no longer a problem.
 
 Note that any hash-based distribution to a set of resolvers may or may not distribute traffic to the resolvers equally. For instance, a popular domain may get a lot of queries, but is just one name from the point of view of the hash. Further work may be needed on this.
+
+Mention public suffix, and also the equivalence lists that Mozilla uses: https://github.com/mozilla-services/shavar-prod-lists/blob/master/disconnect-entitylist.json
 
 ## Suffix-based
 
@@ -121,6 +123,16 @@ The equation then becomes:
 ## Early recommendations
 
 The name- and suffix-based approaches seem to be more capable than random- or round-robin -based approaches.
+
+## Caching considerations {#caching}
+
+Using a common cache for multiple resolvers introduces the possibility that a resolver could learn about queries that were originally directed to another resolvers by observing the absence of queries.  Though this can reduce caching performance, clients can address this by having a per-resolver cache and only using the cache for the selected resolver.
+
+## Consistency considerations
+
+Making the same query to multiple resolvers can result in different answers.  For instance, DNS-based load balancing can lead to different answers being produced over time or for different query origins.
+
+In the extreme, an application might encounter errors as a result of receiving incompatible answers, particularly if a server operator (incorrectly) assumes that different DNS queries for the same client always originate from the same source address.  This is most likely to occur if name-based selection is used, as queries could be related based on information that the client does not consider.
 
 # Further work {#furtherwork}
 

--- a/draft-arkko-abcd-distributed-resolver-selection.md
+++ b/draft-arkko-abcd-distributed-resolver-selection.md
@@ -31,8 +31,8 @@ author:
 normative:
 
 informative:
-  RFC1035: 
-  RFC7258: 
+  RFC1035:
+  RFC7258:
   RFC8446:
   RFC8484:
   I-D.ietf-tls-esni:


### PR DESCRIPTION
I went through the doc and made a lot of changes.  I tried to remove text from the introductory sections, with mixed success.

The conclusion here is that there are two broad categories of division available to us:  requester-based and destination-based.  And that we shouldn't discuss round-robin other than to dismiss it.

In working through this, I'm less enthusiastic about our prospects regarding destination-based hashing.  I can see how you would make it work, but it seems more fragile.

That doesn't mean that requester-based is free from concerns either.  It's fairly common for activities to cross the boundaries that we might choose to use (like when information moves between apps).

Finally, there were a bunch of extra considerations that weren't originally covered.  I took a tilt that those as well, but what I have is probably incomplete.